### PR TITLE
Update activity display to show the username

### DIFF
--- a/activity-tracker.html
+++ b/activity-tracker.html
@@ -117,7 +117,7 @@ Example:
             <div class="activity">
               <img src="[[activity.user.profileImage]]">
               <div>
-                <span class="creator">[[activity.user.firstName]] [[activity.user.lastName]]</span>
+                <span class="creator">[[activity.user.userName]]</span>
                 <span>[[_calculateActivityMessage(activity)]]</span>
                 <div>
                   <relative-time class="creationDate" datetime$="{{activity.creationDate}}"></relative-time>


### PR DESCRIPTION
Since first and last name aren't part of the user object activities aren't correctly displayed.

Needs a new release.